### PR TITLE
Correct the calls for list.random and list.cycle.

### DIFF
--- a/docs/v0.1.x/factories.md
+++ b/docs/v0.1.x/factories.md
@@ -87,12 +87,8 @@ We've also added two methods on the `faker` namespace, `list.cycle` and `list.ra
 import Mirage, {faker} from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
-  name() {
-    return faker.list.cycle('Economics', 'Philosophy', 'English', 'History', 'Mathematics');
-  },
-  students() {
-    return faker.list.random(100, 200, 300, 400, 500);
-  }
+  name: return faker.list.cycle('Economics', 'Philosophy', 'English', 'History', 'Mathematics'),
+  students: return faker.list.random(100, 200, 300, 400, 500)
 });
 ```
 


### PR DESCRIPTION
Both the list.random and list.cycle return a function and will silently fail if called as described in the current documentation. In order to return actual items from the array the property cannot be a function. (e.g. name: verses name())
